### PR TITLE
removes spacing from stack, provides margin to chip

### DIFF
--- a/components/ArticleCard.jsx
+++ b/components/ArticleCard.jsx
@@ -56,7 +56,7 @@ export default function ArticleCard({ isLoading = false, slug: articleSlug, imag
 
           {/* Categories */}
           {categories && categories.length > 0 ? (
-            <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', marginBottom: 2 }}>
+            <Stack direction="row" sx={{ flexWrap: 'wrap', marginBottom: 2 }}>
               {categories.map(({ slug: categorySlug, name }) => {
                 const color = settings.articleCategoryColors[categorySlug];
                 return <Chip
@@ -64,7 +64,7 @@ export default function ArticleCard({ isLoading = false, slug: articleSlug, imag
                   variant={'contained'}
                   component="a"
                   label={name}
-                  sx={color ? { color: '#fff', backgroundColor: color } : {}}
+                  sx={color ? { color: '#fff', backgroundColor: color, margin: .25 } : {}}
                   size={'small'}
                   clickable
                   href={`/blog?category=${categorySlug}`}


### PR DESCRIPTION
Nate pointed out that the Category Chips for the TMDA blogs when there are 3 is stacked right on top of each other:
![image](https://github.com/served-with-honor/tmda-website/assets/58802173/82c1f065-6ecd-4d1a-ae90-b0d7c26f9aa6)

Below is the fix:
![Screenshot 2023-12-06 at 9 57 55 AM](https://github.com/served-with-honor/tmda-website/assets/58802173/2716bd4b-0571-4dcf-902b-efd01a9fbbb6)

